### PR TITLE
pass path parameter to _query method rather than hardcoded path

### DIFF
--- a/src/Contentfully.ts
+++ b/src/Contentfully.ts
@@ -30,7 +30,7 @@ export class Contentfully {
                          options: QueryOptions = {}): Promise<QueryResult> {
 
         // create query
-        const json = await this.contentful.query("/entries",
+        const json = await this.contentful.query(path,
             _.assign({},
         {
                     include: 10,

--- a/test/Contentfully.test.ts
+++ b/test/Contentfully.test.ts
@@ -124,4 +124,30 @@ describe("Content with linked entities and assets", () => {
         expect(rallyEngine).toBe(rotax900);
         expect(rotax900).not.toMatchObject(ROTAX_900);
     });
+
+    it("Should query the contentful client with the correct id retrieving a model", async () => {
+
+        // ensure mock has never been called
+        expect(MockContentfulClient).not.toHaveBeenCalled();
+
+        // create client
+        const contentfulClient = new ContentfulClient(contentfulOptions);
+        const contentfully = new Contentfully(contentfulClient);
+
+        const id = 'test1234';
+        const expectedPath = `/entries/${id}`;
+        const expectedDefaultOptions = {
+            include: 10,
+            limit: 1000,
+            select: "fields,sys.id,sys.contentType"
+        };
+
+        await contentfully.getModel(id);
+
+        // assert invocations
+        expect(MockContentfulClient).toHaveBeenCalledTimes(1);
+        expect(mockClientQuery).toHaveBeenCalledTimes(1);
+        expect(mockClientQuery).toHaveBeenCalledWith(expectedPath, expectedDefaultOptions);
+    });
+
 });


### PR DESCRIPTION
This is fixes [issue #2](https://github.com/nascentdigital/contentfully/issues/2)