### PR TITLE
Adding sys.updatedAt key/value

### DIFF
--- a/src/Contentfully.ts
+++ b/src/Contentfully.ts
@@ -10,6 +10,7 @@ import { QueryResult } from "./QueryResult";
 // constants
 const DEFAULT_SELECT_ID = 'sys.id'
 const DEFAULT_SELECT_CONTENT_TYPE = 'sys.contentType'
+const DEFAULT_SELECT_UPDATED_AT = 'sys.updatedAt'
 
 export class Contentfully {
 
@@ -46,12 +47,15 @@ export class Contentfully {
                 .replace(DEFAULT_SELECT_ID, '')
                 // remove content type
                 .replace(DEFAULT_SELECT_CONTENT_TYPE, '')
+                // remove updated at
+                .replace(DEFAULT_SELECT_UPDATED_AT, '')
                 .trim(',')
                 .value()
         }
 
         // prepend default selects
-        query.select = `${DEFAULT_SELECT_ID},${DEFAULT_SELECT_CONTENT_TYPE},${select}`
+        query.select = `${DEFAULT_SELECT_ID},${DEFAULT_SELECT_CONTENT_TYPE},${DEFAULT_SELECT_UPDATED_AT},${select}`
+        // query.select = ``
 
         // create query
         const json = await this.contentful.query(path,

--- a/test/Contentfully.test.ts
+++ b/test/Contentfully.test.ts
@@ -140,7 +140,7 @@ describe("Content with linked entities and assets", () => {
         const expectedDefaultOptions = {
             include: 10,
             limit: 1000,
-            select: "sys.id,sys.contentType,fields"
+            select: "sys.id,sys.contentType,sys.updatedAt,fields"
         };
 
         await contentfully.getModel(id);
@@ -167,7 +167,7 @@ describe("Content with linked entities and assets", () => {
         const expectedMockArgs = {
             include: 10,
             limit: 1000,
-            select: `sys.id,sys.contentType,selectedFields,another,hello`
+            select: `sys.id,sys.contentType,sys.updatedAt,selectedFields,another,hello`
         };
 
         contentfully.getModels(mockQuery);
@@ -183,13 +183,13 @@ describe("Content with linked entities and assets", () => {
         const contentfully = new Contentfully(contentfulClient);
 
         const mockQuery = {
-            select: "selectedFields, another, hello, sys.id, sys.contentType"
+            select: "selectedFields, another, hello, sys.id, sys.contentType, sys.updatedAt"
         };
         const mockPath = "/entries";
         const expectedMockArgs = {
             include: 10,
             limit: 1000,
-            select: `sys.id,sys.contentType,selectedFields,another,hello`
+            select: `sys.id,sys.contentType,sys.updatedAt,selectedFields,another,hello`
         };
 
         contentfully.getModels(mockQuery);


### PR DESCRIPTION
We need the `sys.updatedAt` field to be exposed so that in our blog we can a post was last updated. Updated the code and then added the test.

Related to #11 
I don't believe we need createdAt, we will use publishDate instead (reasoning in the issue)