### PR TITLE
Feature/add title to media element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1649,7 +1649,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1670,12 +1671,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1690,17 +1693,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1817,7 +1823,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1829,6 +1836,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1843,6 +1851,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1850,12 +1859,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1874,6 +1885,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1954,7 +1966,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1966,6 +1979,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2051,7 +2065,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2087,6 +2102,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2106,6 +2122,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2149,12 +2166,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/Contentfully.ts
+++ b/src/Contentfully.ts
@@ -95,11 +95,13 @@ export class Contentfully {
 
             // capture media file
             const sys = asset.sys;
-            const file = asset.fields.file;
+												const file = asset.fields.file;
+												const title = asset.fields.title;
             const description = asset.fields.description;
             let media = {
                 _id: sys.id,
-                url: file.url,
+																url: file.url,
+																title: title,
                 description: description,
                 contentType: file.contentType,
                 dimensions: _.pick(file.details.image, ["width", "height"]),

--- a/src/Contentfully.ts
+++ b/src/Contentfully.ts
@@ -95,13 +95,13 @@ export class Contentfully {
 
             // capture media file
             const sys = asset.sys;
-												const file = asset.fields.file;
-												const title = asset.fields.title;
+            const file = asset.fields.file;
+            const title = asset.fields.title;
             const description = asset.fields.description;
             let media = {
                 _id: sys.id,
-																url: file.url,
-																title: title,
+                url: file.url,
+                title: title,
                 description: description,
                 contentType: file.contentType,
                 dimensions: _.pick(file.details.image, ["width", "height"]),

--- a/src/entities/Media.ts
+++ b/src/entities/Media.ts
@@ -2,8 +2,8 @@ import {Size} from "./Size";
 
 export interface Media {
     _id: string
-				url: string
-				title: string,
+    url: string
+    title: string,
     description: string
     contentType: string
     dimensions: Size

--- a/src/entities/Media.ts
+++ b/src/entities/Media.ts
@@ -2,7 +2,8 @@ import {Size} from "./Size";
 
 export interface Media {
     _id: string
-    url: string
+				url: string
+				title: string,
     description: string
     contentType: string
     dimensions: Size


### PR DESCRIPTION
We use the `title` field from the Contentful asset in the front end. Unfortunately the title element isn't included in the asset object. With this pull request, the `title` field will be available in the asset.