### PR TITLE
Add title to asset entity

### DIFF
--- a/src/Contentfully.ts
+++ b/src/Contentfully.ts
@@ -192,9 +192,11 @@ export class Contentfully {
         // capture media file
         const file = fields.file;
         const description = fields.description;
+        const title = fields.title;
         let media = {
             _id: sys.id,
             url: file.url,
+            title: title,
             description: description,
             contentType: file.contentType,
             dimensions: pick(file.details.image, ["width", "height"]),

--- a/src/entities/Media.ts
+++ b/src/entities/Media.ts
@@ -3,6 +3,7 @@ import {Size} from "./Size";
 export interface Media {
     _id: string
     url: string
+    title: string
     description: string
     contentType: string
     dimensions: Size


### PR DESCRIPTION
We use the `title` field from the Contentful asset in the frontend. Unfortunately the `title` element isn't included in the asset object. With this pull request, the `title` field will be available in the asset.