### PR TITLE
adding renderRichtext option to render html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "2.5.1",
             "license": "MIT",
             "dependencies": {
+                "@contentful/rich-text-html-renderer": "^15.11.1",
                 "@nascentdigital/scribe": "^0.11.2",
                 "contentful": "^9.1.3",
                 "contentful-management": "^7.44.2",
@@ -615,6 +616,26 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
+        },
+        "node_modules/@contentful/rich-text-html-renderer": {
+            "version": "15.11.1",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-15.11.1.tgz",
+            "integrity": "sha512-DkvApk+spkxECmosGoA8Rmznv59Kmu633Ngm4QnIAt3yTF/Q6nox6/+v4Gv9YAwjYpw/01rXGFIUaP2p7m1fJA==",
+            "dependencies": {
+                "@contentful/rich-text-types": "^15.11.1",
+                "escape-html": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@contentful/rich-text-types": {
+            "version": "15.11.1",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.11.1.tgz",
+            "integrity": "sha512-seO8Nl9cp894v7an6R8isX+HqYwVUesviGULTh/rIj2DCv2tXUU1GCqzSkt84XN6c6nbFYow9+Wzezkxx/IdIA==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -2155,6 +2176,11 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "node_modules/escape-string-regexp": {
             "version": "2.0.0",
@@ -6416,6 +6442,20 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "@contentful/rich-text-html-renderer": {
+            "version": "15.11.1",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-15.11.1.tgz",
+            "integrity": "sha512-DkvApk+spkxECmosGoA8Rmznv59Kmu633Ngm4QnIAt3yTF/Q6nox6/+v4Gv9YAwjYpw/01rXGFIUaP2p7m1fJA==",
+            "requires": {
+                "@contentful/rich-text-types": "^15.11.1",
+                "escape-html": "^1.0.3"
+            }
+        },
+        "@contentful/rich-text-types": {
+            "version": "15.11.1",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.11.1.tgz",
+            "integrity": "sha512-seO8Nl9cp894v7an6R8isX+HqYwVUesviGULTh/rIj2DCv2tXUU1GCqzSkt84XN6c6nbFYow9+Wzezkxx/IdIA=="
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -7718,6 +7758,11 @@
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
             "dev": true
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "escape-string-regexp": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "dev": "tsc -w"
     },
     "dependencies": {
+        "@contentful/rich-text-html-renderer": "^15.11.1",
         "@nascentdigital/scribe": "^0.11.2",
         "contentful": "^9.1.3",
         "contentful-management": "^7.44.2",

--- a/src/Contentfully.ts
+++ b/src/Contentfully.ts
@@ -17,7 +17,7 @@ import {IContentfulClient} from './contentful'
 import {ContentModel, RichText} from './entities'
 import {MediaTransform, QueryOptions} from './QueryOptions'
 import {QueryResult} from './QueryResult'
-
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 
 // constants
 export const DEFAULT_OPTIONS: Readonly<ContentfullyOptions> = {
@@ -61,6 +61,7 @@ export class Contentfully {
 
   public readonly contentfulClient: IContentfulClient
   public readonly options: Readonly<Partial<ContentfullyOptions>>
+  public renderRichtext: boolean
 
 
   public constructor(client: IContentfulClient, options: Readonly<Partial<ContentfullyOptions>> = DEFAULT_OPTIONS) {
@@ -68,6 +69,7 @@ export class Contentfully {
     // initialize instance variables
     this.contentfulClient = client
     this.options = options
+    this.renderRichtext = false
   }
 
   public async getEntry<T extends KeyValueMap & ContentModel>(
@@ -104,6 +106,9 @@ export class Contentfully {
     // parse includes
     const links = await this._createLinks(entries, multiLocale, options.mediaTransform)
 
+    if(options.renderRichtext) {
+      this.renderRichtext = options.renderRichtext
+    }
     // parse core entries
     let items = this._parseEntries(entries.items, links, multiLocale)
 
@@ -388,7 +393,7 @@ export class Contentfully {
     return this._dereferenceLink(value, links, locale)
   }
 
-  private _parseRichTextValue(value: EntryFields.RichText, links: any, locale?: string): RichText[] | undefined {
+  private _parseRichTextValue(value: any, links: any, locale?: string): RichText[] | undefined | string{
 
     // resolve content list
     const {content} = value
@@ -396,6 +401,10 @@ export class Contentfully {
     // skip parsing if no content
     if (!content.length) {
       return undefined
+    }
+
+    if(this.renderRichtext) {
+      return documentToHtmlString(value)
     }
 
     return this._parseRichTextContent(content, links, locale)

--- a/src/QueryOptions.ts
+++ b/src/QueryOptions.ts
@@ -7,4 +7,5 @@ export type MediaTransform = (media: Media) => Promise<Media>
 export interface QueryOptions {
   mediaTransform?: MediaTransform
   flatten?: boolean
+  renderRichtext?: boolean
 }


### PR DESCRIPTION
Added the ability to HTML renderer for the Contentful rich text field type. 

you can enable as follows:

```javascript
const data = await contentfully.getEntries(query,  { renderRichtext: true });
```
so the old response was look something like this:
```javascript
{
        "_id": "26sw3opeSNXmhzS9kgpfde",
        "_type": "helloworld",
        "_createdAt": "2022-02-08T15:03:27.611Z",
        "_updatedAt": "2022-02-16T17:07:27.784Z",
        "title": "Hello World",
        "richtext": [
            {
                "nodeType": "paragraph",
                "content": [
                    {
                        "nodeType": "text",
                        "value": "hallo world",
                        "marks": [
                            "italic",
                            "underline"
                        ]
                    }
                ]
            }
        ]
}
```

after enabling the option It should look something like this:
```javascript
{
        "_id": "26sw3opeSNXmhzS9kgpfde",
        "_type": "helloworld",
        "_createdAt": "2022-02-08T15:03:27.611Z",
        "_updatedAt": "2022-02-16T17:07:27.784Z",
        "title": "Hello World",
        "richtext": "<p><u><i>hallo world</i></u></p>"
}
```

