### PR TITLE
Fix: added check for undefined media file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 1. [Features](#features)
 2. [Installation](#installation)
 3. [Prerequisites](#prerequisites)
-4. [Basic Ussage](#basic-usage)
+4. [Basic Usage](#basic-usage)
 5. [Migration Guide](#migration-guide)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "contentfully",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "contentfully",
-            "version": "3.0.4",
+            "version": "3.0.5",
             "license": "MIT",
             "dependencies": {
                 "@types/json-patch": "^0.0.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "contentfully",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "description": "A simple but performant REST client for Contentful.",
     "keywords": [
         "contentful",

--- a/src/Contentfully.ts
+++ b/src/Contentfully.ts
@@ -264,17 +264,28 @@ export class Contentfully {
 
   private async _toMedia(sys: any, fields: any, mediaTransform?: MediaTransform) {
     // capture media file
-    const file = fields.file
     const description = fields.description
     const title = fields.title
+
+    let url, contentType, size
+    let dimensions = { height: 0, width: 0 }
+
+    // Account for possibility of missing file, if user removes file from media
+    if (fields.file) {
+      url = fields.file.url
+      contentType = fields.file.contentType
+      dimensions = pick(fields.file.details.image, ['width', 'height'])
+      size =  fields.file.details.size
+    }
+
     let media = {
       _id: sys.id,
-      url: file.url,
+      url,
       title: title,
       description: description,
-      contentType: file.contentType,
-      dimensions: pick(file.details.image, ['width', 'height']),
-      size: file.details.size,
+      contentType,
+      dimensions,
+      size,
       version: sys.revision
     }
 
@@ -447,7 +458,7 @@ export class Contentfully {
 
       const {nodeType, data} = item
 
-      
+
       // create baseline rich text
       const richText: RichText = {
         nodeType
@@ -657,7 +668,7 @@ export class Contentfully {
   }
 
   private static createQuery(query: Readonly<any>): EntriesQueries<EntrySkeletonType, any> {
-    
+
     // create default select (if required)
     let select: string[]
     if (!query.select) {


### PR DESCRIPTION
If a user removes a file from an asset, the file would be returned undefined. This would throw an an unhandled error to any consuming application.

A better approach is to leave the values undefined or pre-set, and let the consuming app handle the missing file.