### PR TITLE
Fix/image details check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "contentfully",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "contentfully",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "license": "MIT",
             "dependencies": {
                 "@types/json-patch": "^0.0.33",
@@ -1661,10 +1661,11 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "contentfully",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "description": "A simple but performant REST client for Contentful.",
     "keywords": [
         "contentful",

--- a/src/Contentfully.ts
+++ b/src/Contentfully.ts
@@ -274,8 +274,11 @@ export class Contentfully {
     if (fields.file) {
       url = fields.file.url
       contentType = fields.file.contentType
-      dimensions = pick(fields.file.details.image, ['width', 'height'])
-      size =  fields.file.details.size
+
+      if (fields.file.details) {
+        dimensions = pick(fields.file.details.image, ['width', 'height'])
+        size =  fields.file.details.size
+      }
     }
 
     let media = {


### PR DESCRIPTION
If a content editor closes an asset while its uploading, the file details would not be set and would be returned undefined. This would throw an an unhandled error to any consuming application.

A better approach is to only set the details if they exist, and let the consuming app handle the missing details.
